### PR TITLE
Feat/aop/log trace

### DIFF
--- a/src/main/java/com/numble/whatz/config/aop/aspect/LogTraceAspect.java
+++ b/src/main/java/com/numble/whatz/config/aop/aspect/LogTraceAspect.java
@@ -1,0 +1,40 @@
+package com.numble.whatz.config.aop.aspect;
+
+import com.numble.whatz.config.aop.trace.LogTrace;
+import com.numble.whatz.config.aop.trace.TraceStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Aspect
+@Configuration
+public class LogTraceAspect {
+
+    private final LogTrace logTrace;
+
+    public LogTraceAspect(LogTrace logTrace) {
+        this.logTrace = logTrace;
+    }
+
+    @Around("execution(* com.numble.whatz.web..*(..))")
+    public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
+        TraceStatus status = null;
+
+        try {
+            String message = joinPoint.getSignature().toShortString();
+            status = logTrace.begin(message);
+
+            //로직
+            Object result = joinPoint.proceed();
+
+            logTrace.end(status);
+            return result;
+        } catch (Exception e) {
+            logTrace.exception(status, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/numble/whatz/config/aop/trace/FlowLogTrace.java
+++ b/src/main/java/com/numble/whatz/config/aop/trace/FlowLogTrace.java
@@ -1,0 +1,80 @@
+package com.numble.whatz.config.aop.trace;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FlowLogTrace implements LogTrace {
+
+    private static final String nextDirection = "|-->";
+    private static final String beforeDirection = "|<--";
+    private static final String exceptionDirection = "|<X-";
+
+    // 동시성 문제를 해결하기 위한 쓰레드 로컬
+    ThreadLocal<TraceId> threadLocal = new ThreadLocal<>();
+
+    @Override
+    public TraceStatus begin(String message) {
+        checkBeginThread();
+        TraceId traceId = threadLocal.get();
+        long beforeTime = System.currentTimeMillis();
+        TraceStatus status = new TraceStatus();
+        status.setTime(beforeTime);
+        status.setName(message);
+
+        log.info("[{}]{}", traceId.getId(),
+                addSpace(nextDirection, message, traceId.getLevel()));
+        return status;
+    }
+
+    @Override
+    public void end(TraceStatus status) {
+        checkError(status, null);
+    }
+
+    @Override
+    public void exception(TraceStatus status, Exception e) {
+        checkError(status, e);
+    }
+
+    private void checkError(TraceStatus status, Exception e) {
+        long endTime = System.currentTimeMillis();
+        TraceId traceId = threadLocal.get();
+        long time = endTime - status.getTime();
+        if (e == null)
+            log.info("[{}]{} Time={}ms", traceId.getId(),
+                    addSpace(beforeDirection, status.getName(), traceId.getLevel())
+                    ,time);
+        else
+            log.info("[{}]{} Time={}ms exception={}", traceId.getId(),
+                    addSpace(exceptionDirection, status.getName(), traceId.getLevel())
+                    , time
+                    , e.toString());
+        checkEndThread();
+    }
+
+    private String addSpace(String direction, String message, int level) {
+        String answer = "";
+        for (int i=0; i<level; i++) {
+            answer += "|   ";
+        }
+        return answer + direction + message;
+    }
+
+    private void checkBeginThread() {
+        TraceId traceId = threadLocal.get();
+        if (traceId == null)
+            threadLocal.set(new TraceId());
+        else
+            threadLocal.set(traceId.nextId());
+    }
+
+    private void checkEndThread() {
+        TraceId traceId = threadLocal.get();
+        if (traceId.isFirst())
+            threadLocal.remove();
+        else
+            threadLocal.set(traceId.beforeId());
+    }
+}

--- a/src/main/java/com/numble/whatz/config/aop/trace/LogTrace.java
+++ b/src/main/java/com/numble/whatz/config/aop/trace/LogTrace.java
@@ -1,0 +1,7 @@
+package com.numble.whatz.config.aop.trace;
+
+public interface LogTrace {
+    TraceStatus begin(String message);
+    void end(TraceStatus status);
+    void exception(TraceStatus status, Exception e);
+}

--- a/src/main/java/com/numble/whatz/config/aop/trace/TraceId.java
+++ b/src/main/java/com/numble/whatz/config/aop/trace/TraceId.java
@@ -1,0 +1,34 @@
+package com.numble.whatz.config.aop.trace;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class TraceId {
+
+    private int level;
+    private String id;
+
+    public TraceId() {
+        this.level = 0;
+        this.id = UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    public TraceId(int level, String id) {
+        this.level = level;
+        this.id = id;
+    }
+
+    public TraceId nextId() {
+        return new TraceId(level + 1, id);
+    }
+
+    public boolean isFirst() {
+        return level == 0;
+    }
+
+    public TraceId beforeId() {
+        return new TraceId(level - 1, id);
+    }
+}

--- a/src/main/java/com/numble/whatz/config/aop/trace/TraceStatus.java
+++ b/src/main/java/com/numble/whatz/config/aop/trace/TraceStatus.java
@@ -1,0 +1,11 @@
+package com.numble.whatz.config.aop.trace;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter @Getter
+public class TraceStatus {
+
+    private Long time;
+    private String name;
+}


### PR DESCRIPTION
추가한 기능은 아래와 같습니다.
- web 패키지 안에 있는 파일의 경우에만 동작합니다. 이부분은 추가로 변경할 수 있습니다.
- 로그를 찍어주는 LogTrace가 동작합니다.
      - 컨트롤러 -> 서비스 -> 이런식으로 들어가게되면, 로그 레벨이 오르고 화살표도 더 안쪽으로 출력됩니다. 
      - 서로 다른 세션이 접속하는 경우를 대비하여 ThreadLocal을 이용해 각 세션을 구분하였습니다.
      - 예외가 발생할 경우, 해당 예외가 출력되면서 로그가 진행됩니다. 예외 확인할때 유용할 것 같습니다. 
- 어노테이션을 이용하여 로그를 찍는 방법도 생각하였습니다. 이부분은 추후에 말씀해주시면 수정하겠습니다.